### PR TITLE
Adds power boots to ert and deathsquaddies

### DIFF
--- a/code/datums/martial/power_kick
+++ b/code/datums/martial/power_kick
@@ -1,0 +1,27 @@
+/datum/martial_art/power_kick
+	name = "Power Kick"
+
+/datum/martial_art/power_kick/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	return disarm_pkick(A,D)
+
+/datum/martial_art/power_kick/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	return harm_pkick(A,D)
+
+/datum/martial_art/power_kick/proc/harm_pkick(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
+  if(D.lying)
+    var/atk_verb = pick("stomps", "crushes", "stamps")
+    D.apply_damage(rand(25,30), BRUTE)
+    D.visible_message("<span class='danger'>[A] [atk_verb] [D]!</span>", \
+				"<span class='userdanger'>[A] [atk_verb] you!</span>")
+  else
+    var/atk_verb = pick("punts", "kicks", "cracks", "boots", "slams")
+    D.visible_message("<span class='danger'>[A] [atk_verb] [D]!</span>", \
+				  "<span class='userdanger'>[A] [atk_verb] you!</span>")
+	  D.apply_damage(rand(8,10), BRUTE)
+	  playsound(get_turf(D), 'sound/weapons/punch1.ogg', 25, 1, -1)
+	    if(prob(15) && !D.lying) //dunno about chances but it's less than sleeping carp and has less knockdown so i have high hopes
+		  D.visible_message("<span class='warning'>[D] is knocked down by a powerful kick from [A]!</span>", "<span class='userdanger'>The kick sends you sprawling to the floor!</span>")
+		  D.Knockdown(60)
+	add_logs(A, D, "[atk_verb] (Power Kick)")
+	return 1


### PR DESCRIPTION
:cl: ArmAndHammer
add: Added power boots!
add: they kick HARD, gamers. make sure they're on the ground for best effect!
add: they also kick through DOORS so they're great for breaching like a cool guy
/:cl:

[why]: wyzack wants /betterbreaching/ with deathsquads and erts and i can't agree more. it's cool, it's in the code, and soon some fucker will add it to rnd. hell yeah

TO DO:
the item that grants these
adding it to loadouts of ert
adding disarm kicks
adding kicking down doors
removing awesine (DONE)
